### PR TITLE
Support for Register orgid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile('no.fint:fint-relations:2.0.0')
     compile('no.fint:fint-events:2.2.0-rc-1')
     compile('no.fint:fint-audit-mongo-plugin:1.4.1')
-    compile('no.fint:fint-cache:2.0.1-rc-3')
+    compile('no.fint:fint-cache:2.0.1')
     compile('no.fint:fint-dependencies:0.0.3')
 
     compile('org.projectlombok:lombok')

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
     compile('no.fint:fint-event-model:3.0.0')
     compile('no.fint:fint-relations:2.0.0')
-    compile('no.fint:fint-events:2.1.0')
+    compile('no.fint:fint-events:2.2.0-rc-1')
     compile('no.fint:fint-audit-mongo-plugin:1.4.1')
     compile('no.fint:fint-cache:2.0.1-rc-3')
     compile('no.fint:fint-dependencies:0.0.3')

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     compile('org.springframework.boot:spring-boot-starter-web')
     runtime('org.springframework.boot:spring-boot-devtools')
+    runtime('org.springframework.boot:spring-boot-starter-actuator')
 
     testCompile('no.fint:fint-test-utils:0.0.4')
     testCompile("cglib:cglib-nodep:${cglibVersion}")
@@ -58,13 +59,13 @@ dependencies {
 }
 
 task copyExternalDependencies(type: Copy) {
-    from configurations.compile
+    from configurations.runtime
     into "$buildDir/deps/external"
     exclude '**/fint-*.jar'
 }
 
 task copyFintDependencies(type: Copy) {
-    from configurations.compile
+    from configurations.runtime
     into "$buildDir/deps/fint"
     include '**/fint-*.jar'
 }
@@ -79,7 +80,7 @@ jar {
                 "Main-Class": "no.fint.consumer.Application",
                 "Specification-Version": "${apiVersion}",
                 "Implementation-Version": "${version}",
-                "Class-Path": configurations.compile.collect { it.getName() }.join(' ')
+                "Class-Path": configurations.runtime.collect { it.getName() }.join(' ')
         )
     }
 }

--- a/src/main/java/no/fint/consumer/config/ConsumerProps.java
+++ b/src/main/java/no/fint/consumer/config/ConsumerProps.java
@@ -1,15 +1,37 @@
 package no.fint.consumer.config;
 
 import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @Component
 public class ConsumerProps {
 
-    @Value("${fint.events.orgIds:mock.no}")
-    private String[] orgs;
+    @Value("${fint.consumer.override-org-id:false}")
+    private boolean overrideOrgId;
+
+    @Value("${fint.consumer.default-client:FINT}")
+    private String defaultClient;
+
+    @Value("${fint.consumer.default-org-id:fint.no}")
+    private String defaultOrgId;
+
+    private Set<String> assets;
+
+    @Autowired
+    private void setupOrgs(@Value("${fint.events.orgIds:}") String[] orgs) {
+        assets = new HashSet<>(Arrays.asList(orgs));
+    }
+
+    public String[] getOrgs() {
+        return assets.toArray(new String[0]);
+    }
 
 }
 

--- a/src/main/java/no/fint/consumer/event/EventListener.java
+++ b/src/main/java/no/fint/consumer/event/EventListener.java
@@ -42,7 +42,7 @@ public class EventListener implements FintEventListener {
         fintEvents.registerUpstreamSystemListener(this);
         if (cacheServices == null)
             cacheServices = Collections.emptyList();
-    	for (String orgId : props.getOrgs()) {
+    	for (String orgId : props.getAssets()) {
     		fintEvents.registerUpstreamListener(orgId, this);
     	}
     	log.info("Upstream listeners registered.");
@@ -53,9 +53,11 @@ public class EventListener implements FintEventListener {
         log.debug("Received event: {}", event);
         log.trace("Event data: {}", event.getData());
         if (event.isRegisterOrgId()) {
-            log.info("Registering orgId {} for {} ...", event.getOrgId(), event.getClient());
-            fintEvents.registerUpstreamListener(event.getOrgId(), this);
-            cacheServices.forEach(c -> c.createCache(event.getOrgId()));
+            if (props.getAssets().add(event.getOrgId())) {
+                log.info("Registering orgId {} for {}", event.getOrgId(), event.getClient());
+                fintEvents.registerUpstreamListener(event.getOrgId(), this);
+                cacheServices.forEach(c -> c.createCache(event.getOrgId()));
+            }
             return;
         }
         if (statusCache.containsKey(event.getCorrId())) {

--- a/src/main/java/no/fint/consumer/event/EventListener.java
+++ b/src/main/java/no/fint/consumer/event/EventListener.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 @Component
 public class EventListener implements FintEventListener {
 
-    @Autowired
+    @Autowired(required = false)
     private List<CacheService> cacheServices;
     
 	@Autowired
@@ -38,6 +39,9 @@ public class EventListener implements FintEventListener {
 
     @PostConstruct
     public void init() {
+        fintEvents.registerUpstreamSystemListener(this);
+        if (cacheServices == null)
+            cacheServices = Collections.emptyList();
     	for (String orgId : props.getOrgs()) {
     		fintEvents.registerUpstreamListener(orgId, this);
     	}
@@ -48,6 +52,12 @@ public class EventListener implements FintEventListener {
 	public void accept(Event event) {
         log.debug("Received event: {}", event);
         log.trace("Event data: {}", event.getData());
+        if (event.isRegisterOrgId()) {
+            log.info("Registering orgId {} for {} ...", event.getOrgId(), event.getClient());
+            fintEvents.registerUpstreamListener(event.getOrgId(), this);
+            cacheServices.forEach(c -> c.createCache(event.getOrgId()));
+            return;
+        }
         if (statusCache.containsKey(event.getCorrId())) {
             statusCache.put(event.getCorrId(), event);
         }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,3 +1,7 @@
+spring:
+ application:
+  name: fint-consumer-skeleton
+
 fint:
  events:
   orgIds: mock.no


### PR DESCRIPTION
Add support for REGISTER_ORG_ID actions from provider, and create caches for new asset IDs.

Relates to https://github.com/FINTlibs/fint-events/commit/4497ed5817230a4f3a4638404e57b131a69c2228