### PR TITLE
Fail on unknown JSON properties?

### DIFF
--- a/src/main/java/no/fint/consumer/config/Config.java
+++ b/src/main/java/no/fint/consumer/config/Config.java
@@ -1,6 +1,7 @@
 package no.fint.consumer.config;
 
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,7 @@ public class Config {
 
     @PostConstruct
     public void init() {
-        objectMapper.setDateFormat(new ISO8601DateFormat());
+        objectMapper.setDateFormat(new ISO8601DateFormat()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     @Qualifier("linkMapper")


### PR DESCRIPTION
Should consumers fail when deserializing JSON with unknown properties?

This is enabled in Jackson by default.