### PR TITLE
Feature/disable hazelcast backup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM gradle:4.10.3-jdk8-alpine as builder
-USER root
+FROM eclipse-temurin:8-jdk AS builder
+WORKDIR /workspace
 COPY . .
 ARG apiVersion
 ARG buildFlags=""
-RUN gradle --no-daemon ${buildFlags} -PapiVersion=${apiVersion} build
+RUN ./gradlew --no-daemon ${buildFlags} -PapiVersion=${apiVersion} build
 
 FROM gcr.io/distroless/java:8
-ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
-COPY --from=builder /home/gradle/build/deps/external/*.jar /data/
-COPY --from=builder /home/gradle/build/deps/fint/*.jar /data/
-COPY --from=builder /home/gradle/build/libs/fint-consumer-skeleton-*.jar /data/fint-consumer-skeleton.jar
+ENV JAVA_TOOL_OPTIONS="-XX:+ExitOnOutOfMemoryError"
+COPY --from=builder /workspace/build/deps/external/*.jar /data/
+COPY --from=builder /workspace/build/deps/fint/*.jar /data/
+COPY --from=builder /workspace/build/libs/fint-consumer-skeleton-*.jar /data/fint-consumer-skeleton.jar
 CMD ["/data/fint-consumer-skeleton.jar"]

--- a/src/main/java/no/novari/fint/consumer/consumer/status/StatusCache.java
+++ b/src/main/java/no/novari/fint/consumer/consumer/status/StatusCache.java
@@ -10,7 +10,7 @@ import no.fint.event.model.Event;
 import no.fint.event.model.EventResponse;
 import no.fint.event.model.Operation;
 import no.fint.event.model.Status;
-import no.fint.model.resource.FintLinks;
+import no.novari.fint.model.resource.FintLinks;
 import no.fint.relations.FintLinker;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ springfox:
   title: '@title@'
   version: '@version@'
 
+fint:
+  hazelcast:
+    config: fint-consumer-hazelcast.xml
+
+
 spring:
   mvc:
     logResolvedException: false

--- a/src/main/resources/fint-consumer-hazelcast.xml
+++ b/src/main/resources/fint-consumer-hazelcast.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast
+        xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd"
+        xmlns="http://www.hazelcast.com/schema/config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <group>
+        <name>fint-hazelcast</name>
+        <password>fint-hazelcast</password>
+    </group>
+
+    <properties>
+        <property name="hazelcast.logging.type">slf4j</property>
+    </properties>
+
+    <map name="default">
+        <backup-count>0</backup-count>
+        <async-backup-count>0</async-backup-count>
+    </map>
+
+    <queue name="default">
+        <backup-count>0</backup-count>
+        <async-backup-count>0</async-backup-count>
+    </queue>
+</hazelcast>

--- a/src/test/groovy/no/fint/consumer/test/TestObject.groovy
+++ b/src/test/groovy/no/fint/consumer/test/TestObject.groovy
@@ -1,7 +1,7 @@
 package no.fint.consumer.test
 
-import no.fint.model.resource.FintLinks
-import no.fint.model.resource.Link
+import no.novari.fint.model.resource.FintLinks
+import no.novari.fint.model.resource.Link
 
 class TestObject implements FintLinks {
     @Override


### PR DESCRIPTION
As hazelcast makes a backup by default, we use a lot of unnecessary memory. This disables the backup.